### PR TITLE
add sort direction toggle

### DIFF
--- a/src/components/ApplicationLeaderboard.tsx
+++ b/src/components/ApplicationLeaderboard.tsx
@@ -51,8 +51,8 @@ export const ApplicationLeaderboard: React.FC<Props> = ({
   ];
 
   const headers = [
-    { key: 'rank', label: 'Rank' },
-    { key: 'username', label: 'Username' },
+    { key: 'rank', label: 'Rank', static: true },
+    { key: 'username', label: 'Username', static: true },
     { key: 'applied', label: 'Applied' },
   ];
 
@@ -81,6 +81,7 @@ export const ApplicationLeaderboard: React.FC<Props> = ({
       <Box>
         <Leaderboard
           data={applicationData}
+          sortDirection="desc"
           orderBy={order}
           orderColKey={orderColKey(order)}
           headers={headers}

--- a/src/components/ApplicationLeaderboard.tsx
+++ b/src/components/ApplicationLeaderboard.tsx
@@ -1,6 +1,11 @@
 import { Flex, Spinner, Text, Box } from '@chakra-ui/react';
 import React from 'react';
-import { ApplicationOrderBy, LeaderboardType, Row } from '../types';
+import {
+  ApplicationOrderBy,
+  LeaderboardType,
+  Row,
+  SortDirection,
+} from '../types';
 import Leaderboard from './Leaderboard';
 import { OrderBySelect } from './OrderBySelect';
 import { lastUpdated } from '../utils';
@@ -81,7 +86,7 @@ export const ApplicationLeaderboard: React.FC<Props> = ({
       <Box>
         <Leaderboard
           data={applicationData}
-          sortDirection="desc"
+          sortDirection={SortDirection.Desc}
           orderBy={order}
           orderColKey={orderColKey(order)}
           headers={headers}

--- a/src/components/ApplicationLeaderboard.tsx
+++ b/src/components/ApplicationLeaderboard.tsx
@@ -2,6 +2,7 @@ import { Flex, Spinner, Text, Box } from '@chakra-ui/react';
 import React from 'react';
 import {
   ApplicationOrderBy,
+  LeaderboardHeader,
   LeaderboardType,
   Row,
   SortDirection,
@@ -55,7 +56,7 @@ export const ApplicationLeaderboard: React.FC<Props> = ({
     { value: ApplicationOrderBy.Recent, label: 'Recently Applied' },
   ];
 
-  const headers = [
+  const headers: LeaderboardHeader[] = [
     { key: 'rank', label: 'Rank', static: true },
     { key: 'username', label: 'Username', static: true },
     { key: 'applied', label: 'Applied' },

--- a/src/components/GithubLeaderboard.tsx
+++ b/src/components/GithubLeaderboard.tsx
@@ -1,6 +1,6 @@
 import { Flex, Spinner, Text, Box, Link } from '@chakra-ui/react';
-import React from 'react';
-import { GitHubOrderBy, LeaderboardType, Row } from '../types';
+import React, { useState } from 'react';
+import { GitHubOrderBy, LeaderboardType, Row, SortDirection } from '../types';
 import Leaderboard from './Leaderboard';
 import { OrderBySelect } from './OrderBySelect';
 import { getGithubProfileURL, lastUpdated } from '../utils';
@@ -27,6 +27,7 @@ export const GithubLeaderboard: React.FC<Props> = ({
   order,
   onOrderChange,
 }) => {
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const {
     isLoading,
     error,
@@ -56,12 +57,39 @@ export const GithubLeaderboard: React.FC<Props> = ({
   ];
 
   const headers = [
-    { key: 'rank', label: 'Rank' },
-    { key: 'username', label: 'Username' },
+    { key: 'rank', label: 'Rank', static: true },
+    { key: 'username', label: 'Username', static: true },
     { key: 'totalCommits', label: 'Commits' },
     { key: 'totalPrs', label: 'PRs' },
     { key: 'followers', label: 'Followers' },
   ];
+
+  const getOrderByFromKey = (key: string): GitHubOrderBy | null => {
+    switch (key) {
+      case 'totalCommits':
+        return GitHubOrderBy.Commits;
+      case 'totalPrs':
+        return GitHubOrderBy.Prs;
+      case 'followers':
+        return GitHubOrderBy.Followers;
+      default:
+        return null;
+    }
+  };
+
+  const handleSort = (key: string) => {
+    const newOrder = getOrderByFromKey(key);
+    if (newOrder) {
+      // if active column clicked
+      if (newOrder === order) {
+        setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+      } else {
+        // desc by default
+        setSortDirection('desc');
+        onOrderChange(newOrder);
+      }
+    }
+  };
 
   const orderColKey = (order: GitHubOrderBy) => {
     switch (order) {
@@ -92,9 +120,11 @@ export const GithubLeaderboard: React.FC<Props> = ({
         <Leaderboard
           data={githubData}
           orderBy={order}
+          sortDirection={sortDirection}
           orderColKey={orderColKey(order)}
           headers={headers}
           cellFormatter={formatLeaderboardEntry}
+          onSort={handleSort}
         />
       </Box>
     </Box>

--- a/src/components/GithubLeaderboard.tsx
+++ b/src/components/GithubLeaderboard.tsx
@@ -1,6 +1,12 @@
 import { Flex, Spinner, Text, Box, Link } from '@chakra-ui/react';
 import React, { useState } from 'react';
-import { GitHubOrderBy, LeaderboardType, Row, SortDirection } from '../types';
+import {
+  GitHubOrderBy,
+  LeaderboardHeader,
+  LeaderboardType,
+  Row,
+  SortDirection,
+} from '../types';
 import Leaderboard from './Leaderboard';
 import { OrderBySelect } from './OrderBySelect';
 import { getGithubProfileURL, lastUpdated } from '../utils';
@@ -58,7 +64,7 @@ export const GithubLeaderboard: React.FC<Props> = ({
     { value: GitHubOrderBy.Followers, label: 'Followers' },
   ];
 
-  const headers = [
+  const headers: LeaderboardHeader[] = [
     { key: 'rank', label: 'Rank', static: true },
     { key: 'username', label: 'Username', static: true },
     { key: 'totalCommits', label: 'Commits' },
@@ -66,7 +72,7 @@ export const GithubLeaderboard: React.FC<Props> = ({
     { key: 'followers', label: 'Followers' },
   ];
 
-  const getOrderByFromKey = (key: string): GitHubOrderBy | null => {
+  const getOrderByFromKey = (key: keyof Row): GitHubOrderBy | null => {
     switch (key) {
       case 'totalCommits':
         return GitHubOrderBy.Commits;
@@ -79,7 +85,7 @@ export const GithubLeaderboard: React.FC<Props> = ({
     }
   };
 
-  const handleSort = (key: string) => {
+  const handleSort = (key: keyof Row) => {
     const newOrder = getOrderByFromKey(key);
     if (newOrder) {
       // if active column clicked

--- a/src/components/GithubLeaderboard.tsx
+++ b/src/components/GithubLeaderboard.tsx
@@ -27,7 +27,9 @@ export const GithubLeaderboard: React.FC<Props> = ({
   order,
   onOrderChange,
 }) => {
-  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const [sortDirection, setSortDirection] = useState<SortDirection>(
+    SortDirection.Desc
+  );
   const {
     isLoading,
     error,
@@ -82,10 +84,12 @@ export const GithubLeaderboard: React.FC<Props> = ({
     if (newOrder) {
       // if active column clicked
       if (newOrder === order) {
-        setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+        setSortDirection((prev) =>
+          prev === SortDirection.Asc ? SortDirection.Desc : SortDirection.Asc
+        );
       } else {
         // desc by default
-        setSortDirection('desc');
+        setSortDirection(SortDirection.Desc);
         onOrderChange(newOrder);
       }
     }

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -12,23 +12,32 @@ import {
   Icon,
 } from '@chakra-ui/react';
 import { ChevronUpIcon } from '@chakra-ui/icons';
-import { LeaderboardHeader, Ordering, LeaderboardEntry } from '../types';
+import {
+  LeaderboardHeader,
+  Ordering,
+  LeaderboardEntry,
+  SortDirection,
+  Row,
+} from '../types';
 import { devPrint } from './utils/RandomUtils';
-import { Row } from '../types';
 
 interface LeaderboardProps {
   data: LeaderboardEntry[];
   orderBy: Ordering;
+  sortDirection: SortDirection;
   headers: LeaderboardHeader[];
   orderColKey: string;
   cellFormatter: (key: keyof Row, row: Row) => React.ReactNode;
+  onSort?: (key: string) => void;
 }
 
 const Leaderboard: React.FC<LeaderboardProps> = ({
   data,
+  sortDirection,
   orderColKey,
   headers,
   cellFormatter,
+  onSort,
 }) => {
   if (data.length === 0) {
     return (
@@ -39,6 +48,24 @@ const Leaderboard: React.FC<LeaderboardProps> = ({
       </Flex>
     );
   }
+
+  // Sort data based on direction
+  const sortedData = React.useMemo(() => {
+    const sorted = [...data];
+    if (sortDirection === 'asc') {
+      sorted.reverse();
+    }
+    return sorted;
+  }, [data, sortDirection]);
+
+  // Ranks based on descending order
+  const rankMap = React.useMemo(() => {
+    const map = new Map();
+    data.forEach((item, index) => {
+      map.set(item.username, index + 1);
+    });
+    return map;
+  }, [data]);
 
   return (
     <Box borderWidth="1px" borderRadius="xl" overflow="scroll" bg="white">
@@ -53,11 +80,22 @@ const Leaderboard: React.FC<LeaderboardProps> = ({
                 borderBottomColor="gray.200"
                 color="gray.600"
                 fontSize="xs"
+                cursor={header.static ? 'default' : 'pointer'}
+                onClick={() => onSort?.(header.key)}
+                _hover={{ bg: 'gray.50' }}
               >
                 <Flex align="center" gap={2}>
                   {header.label}
                   {header.key === orderColKey && (
-                    <Icon as={ChevronUpIcon} color="gray.400" boxSize={5} />
+                    <Icon
+                      as={ChevronUpIcon}
+                      color="gray.400"
+                      boxSize={5}
+                      transform={
+                        sortDirection === 'desc' ? 'rotate(180deg)' : undefined
+                      }
+                      transition="transform 0.2s"
+                    />
                   )}
                 </Flex>
               </Th>
@@ -65,7 +103,7 @@ const Leaderboard: React.FC<LeaderboardProps> = ({
           </Tr>
         </Thead>
         <Tbody>
-          {data.map((row, index) => (
+          {sortedData.map((row) => (
             <Tr
               key={row.username}
               _hover={{ bg: 'gray.50' }}
@@ -79,7 +117,7 @@ const Leaderboard: React.FC<LeaderboardProps> = ({
                   fontSize={header.key === 'username' ? 'sm' : 'xs'}
                 >
                   {Cell(
-                    { ...row, rank: index + 1 },
+                    { ...row, rank: rankMap.get(row.username) },
                     headers,
                     header,
                     cellFormatter

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -39,16 +39,6 @@ const Leaderboard: React.FC<LeaderboardProps> = ({
   cellFormatter,
   onSort,
 }) => {
-  if (data.length === 0) {
-    return (
-      <Flex justifyContent="center">
-        <Text fontWeight="semibold" fontSize="larger">
-          No data available.
-        </Text>
-      </Flex>
-    );
-  }
-
   // Sort data based on direction
   const sortedData = React.useMemo(() => {
     const sorted = [...data];
@@ -66,6 +56,16 @@ const Leaderboard: React.FC<LeaderboardProps> = ({
     });
     return map;
   }, [data]);
+
+  if (data.length === 0) {
+    return (
+      <Flex justifyContent="center">
+        <Text fontWeight="semibold" fontSize="larger">
+          No data available.
+        </Text>
+      </Flex>
+    );
+  }
 
   return (
     <Box borderWidth="1px" borderRadius="xl" overflow="scroll" bg="white">

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -26,9 +26,9 @@ interface LeaderboardProps {
   orderBy: Ordering;
   sortDirection: SortDirection;
   headers: LeaderboardHeader[];
-  orderColKey: string;
+  orderColKey: keyof Row | '';
   cellFormatter: (key: keyof Row, row: Row) => React.ReactNode;
-  onSort?: (key: string) => void;
+  onSort?: (key: keyof Row) => void;
 }
 
 const Leaderboard: React.FC<LeaderboardProps> = ({

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -42,7 +42,7 @@ const Leaderboard: React.FC<LeaderboardProps> = ({
   // Sort data based on direction
   const sortedData = React.useMemo(() => {
     const sorted = [...data];
-    if (sortDirection === 'asc') {
+    if (sortDirection === SortDirection.Asc) {
       sorted.reverse();
     }
     return sorted;
@@ -92,7 +92,7 @@ const Leaderboard: React.FC<LeaderboardProps> = ({
                       color="gray.400"
                       boxSize={5}
                       transform={
-                        sortDirection === 'desc' ? 'rotate(180deg)' : undefined
+                        sortDirection === SortDirection.Asc ? 'rotate(180deg)' : undefined
                       }
                       transition="transform 0.2s"
                     />

--- a/src/components/LeetcodeLeaderboard.tsx
+++ b/src/components/LeetcodeLeaderboard.tsx
@@ -44,7 +44,9 @@ export const LeetcodeLeaderboard: React.FC<Props> = ({
   order,
   onOrderChange,
 }) => {
-  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const [sortDirection, setSortDirection] = useState<SortDirection>(
+    SortDirection.Desc
+  );
   const {
     isLoading,
     error,
@@ -118,9 +120,11 @@ export const LeetcodeLeaderboard: React.FC<Props> = ({
     const newOrder = getOrderByFromKey(key);
     if (newOrder) {
       if (newOrder === order) {
-        setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+        setSortDirection((prev) =>
+          prev === SortDirection.Asc ? SortDirection.Desc : SortDirection.Asc
+        );
       } else {
-        setSortDirection('desc');
+        setSortDirection(SortDirection.Desc);
         onOrderChange(newOrder);
       }
     }

--- a/src/components/LeetcodeLeaderboard.tsx
+++ b/src/components/LeetcodeLeaderboard.tsx
@@ -1,6 +1,12 @@
 import { Flex, Spinner, Text, Box, Link } from '@chakra-ui/react';
 import React, { useState } from 'react';
-import { LeaderboardType, LeetCodeOrderBy, Row, SortDirection } from '../types';
+import {
+  LeaderboardHeader,
+  LeaderboardType,
+  LeetCodeOrderBy,
+  Row,
+  SortDirection,
+} from '../types';
 import Leaderboard from './Leaderboard';
 import { OrderBySelect } from './OrderBySelect';
 import { getLeetcodeProfileURL, lastUpdated } from '../utils';
@@ -75,7 +81,7 @@ export const LeetcodeLeaderboard: React.FC<Props> = ({
     { value: LeetCodeOrderBy.Hard, label: 'Hard Problems' },
   ];
 
-  const headers = [
+  const headers: LeaderboardHeader[] = [
     { key: 'rank', label: 'Rank', static: true },
     { key: 'username', label: 'Username', static: true },
     { key: 'totalSolved', label: 'Total' },
@@ -101,7 +107,7 @@ export const LeetcodeLeaderboard: React.FC<Props> = ({
     }
   };
 
-  const getOrderByFromKey = (key: string): LeetCodeOrderBy | undefined => {
+  const getOrderByFromKey = (key: keyof Row): LeetCodeOrderBy | undefined => {
     switch (key) {
       case 'totalSolved':
         return LeetCodeOrderBy.Total;
@@ -116,7 +122,7 @@ export const LeetcodeLeaderboard: React.FC<Props> = ({
     }
   };
 
-  const handleSort = (key: string) => {
+  const handleSort = (key: keyof Row) => {
     const newOrder = getOrderByFromKey(key);
     if (newOrder) {
       if (newOrder === order) {

--- a/src/components/LeetcodeLeaderboard.tsx
+++ b/src/components/LeetcodeLeaderboard.tsx
@@ -1,6 +1,6 @@
 import { Flex, Spinner, Text, Box, Link } from '@chakra-ui/react';
-import React from 'react';
-import { LeaderboardType, LeetCodeOrderBy, Row } from '../types';
+import React, { useState } from 'react';
+import { LeaderboardType, LeetCodeOrderBy, Row, SortDirection } from '../types';
 import Leaderboard from './Leaderboard';
 import { OrderBySelect } from './OrderBySelect';
 import { getLeetcodeProfileURL, lastUpdated } from '../utils';
@@ -44,6 +44,7 @@ export const LeetcodeLeaderboard: React.FC<Props> = ({
   order,
   onOrderChange,
 }) => {
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const {
     isLoading,
     error,
@@ -73,8 +74,8 @@ export const LeetcodeLeaderboard: React.FC<Props> = ({
   ];
 
   const headers = [
-    { key: 'rank', label: 'Rank' },
-    { key: 'username', label: 'Username' },
+    { key: 'rank', label: 'Rank', static: true },
+    { key: 'username', label: 'Username', static: true },
     { key: 'totalSolved', label: 'Total' },
     { key: 'easySolved', label: 'Easy' },
     { key: 'mediumSolved', label: 'Medium' },
@@ -98,6 +99,33 @@ export const LeetcodeLeaderboard: React.FC<Props> = ({
     }
   };
 
+  const getOrderByFromKey = (key: string): LeetCodeOrderBy | undefined => {
+    switch (key) {
+      case 'totalSolved':
+        return LeetCodeOrderBy.Total;
+      case 'easySolved':
+        return LeetCodeOrderBy.Easy;
+      case 'mediumSolved':
+        return LeetCodeOrderBy.Medium;
+      case 'hardSolved':
+        return LeetCodeOrderBy.Hard;
+      default:
+        return undefined;
+    }
+  };
+
+  const handleSort = (key: string) => {
+    const newOrder = getOrderByFromKey(key);
+    if (newOrder) {
+      if (newOrder === order) {
+        setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+      } else {
+        setSortDirection('desc');
+        onOrderChange(newOrder);
+      }
+    }
+  };
+
   return (
     <Box>
       <Flex justify="space-between" align="center" mb={4}>
@@ -114,9 +142,11 @@ export const LeetcodeLeaderboard: React.FC<Props> = ({
         <Leaderboard
           data={leetcodeData}
           orderBy={order}
+          sortDirection={sortDirection}
           orderColKey={orderColKey(order)}
           headers={headers}
           cellFormatter={formatLeaderboardEntry}
+          onSort={handleSort}
         />
       </Box>
     </Box>

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,6 +132,7 @@ export enum ApplicationOrderBy {
 export interface LeaderboardHeader {
   key: string;
   label: string;
+  static?: boolean;
 }
 
 export type Row = {
@@ -150,3 +151,5 @@ export type Ordering = GitHubOrderBy | LeetCodeOrderBy | ApplicationOrderBy;
 export type LeaderboardDataHandler = (
   order: Ordering
 ) => Promise<LeaderboardEntry[]>;
+
+export type SortDirection = 'asc' | 'desc';

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,7 +130,7 @@ export enum ApplicationOrderBy {
 }
 
 export interface LeaderboardHeader {
-  key: string;
+  key: keyof Row;
   label: string;
   static?: boolean;
 }
@@ -145,6 +145,7 @@ export type Row = {
   totalCommits?: number;
   totalPrs?: number;
   followers?: number;
+  applied?: number;
 };
 
 export type Ordering = GitHubOrderBy | LeetCodeOrderBy | ApplicationOrderBy;

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,4 +152,7 @@ export type LeaderboardDataHandler = (
   order: Ordering
 ) => Promise<LeaderboardEntry[]>;
 
-export type SortDirection = 'asc' | 'desc';
+export enum SortDirection {
+  Asc = 'asc',
+  Desc = 'desc',
+}


### PR DESCRIPTION
Author: Bhavik

## What changes were made?
- add toggle to change sort order between asc and desc
- make column titles clickable as an alternative to the dropdown

## Why are these changes important/necessary?
- There was a deceiving arrow that didn't work. This change improves leaderboard interactivity
