### PR TITLE
Add pagination to the attendance leaderboard

### DIFF
--- a/src/components/AttendanceLeaderboard.tsx
+++ b/src/components/AttendanceLeaderboard.tsx
@@ -11,7 +11,6 @@ import Leaderboard from './Leaderboard';
 import { OrderBySelect } from './OrderBySelect';
 import { lastUpdated } from '../utils';
 import { useLeaderboard } from '../hooks/useLeaderboard';
-import { devPrint } from './utils/RandomUtils';
 
 interface Props {
   order: EngagementOrderBy;
@@ -135,7 +134,6 @@ export const AttendanceLeaderboard: React.FC<Props> = ({
             isDisabled={!nextPage}
             onClick={() => {
               setPageUrl(nextPage!);
-              devPrint(nextPage);
             }}
           >
             Next

--- a/src/components/AttendanceLeaderboard.tsx
+++ b/src/components/AttendanceLeaderboard.tsx
@@ -121,7 +121,7 @@ export const AttendanceLeaderboard: React.FC<Props> = ({
           cellFormatter={formatLeaderboardEntry}
           onSort={handleSort}
         />
-        <HStack w="100%" justify={'center'} mt={2}>
+        <HStack w="100%" justify="center" mt={2}>
           <Button
             isDisabled={!previousPage}
             onClick={() => {

--- a/src/components/AttendanceLeaderboard.tsx
+++ b/src/components/AttendanceLeaderboard.tsx
@@ -1,4 +1,4 @@
-import { Flex, Spinner, Text, Box } from '@chakra-ui/react';
+import { Flex, Spinner, Text, Box, HStack, Button } from '@chakra-ui/react';
 import React, { useState } from 'react';
 import {
   EngagementOrderBy,
@@ -11,6 +11,7 @@ import Leaderboard from './Leaderboard';
 import { OrderBySelect } from './OrderBySelect';
 import { lastUpdated } from '../utils';
 import { useLeaderboard } from '../hooks/useLeaderboard';
+import { devPrint } from './utils/RandomUtils';
 
 interface Props {
   order: EngagementOrderBy;
@@ -28,11 +29,16 @@ export const AttendanceLeaderboard: React.FC<Props> = ({
   const [sortDirection, setSortDirection] = useState<SortDirection>(
     SortDirection.Desc
   );
+
+  const [pageUrl, setPageUrl] = useState<string>();
+
   const {
     isLoading,
     error,
     leaderboardData: attendanceData,
-  } = useLeaderboard(LeaderboardType.Attendance, order);
+    nextPage,
+    previousPage,
+  } = useLeaderboard(LeaderboardType.Attendance, order, pageUrl);
 
   if (isLoading) {
     return (
@@ -116,6 +122,25 @@ export const AttendanceLeaderboard: React.FC<Props> = ({
           cellFormatter={formatLeaderboardEntry}
           onSort={handleSort}
         />
+        <HStack w="100%" justify={'center'} mt={2}>
+          <Button
+            isDisabled={!previousPage}
+            onClick={() => {
+              setPageUrl(previousPage!);
+            }}
+          >
+            Previous
+          </Button>
+          <Button
+            isDisabled={!nextPage}
+            onClick={() => {
+              setPageUrl(nextPage!);
+              devPrint(nextPage);
+            }}
+          >
+            Next
+          </Button>
+        </HStack>
       </Box>
     </Box>
   );

--- a/src/hooks/useLeaderboard.tsx
+++ b/src/hooks/useLeaderboard.tsx
@@ -3,7 +3,6 @@ import { LeaderboardType, Ordering, LeaderboardEntry } from '../types';
 import { useToast } from '@chakra-ui/react';
 import { getLeaderboardDataHandlerFromType } from '../services/leaderboard';
 import { assertTypeAndOrderingIntegrity } from '../utils';
-import { devPrint } from '../components/utils/RandomUtils';
 
 interface CacheEntry {
   data: LeaderboardEntry[];
@@ -52,12 +51,10 @@ export const useLeaderboard = (
     setError(undefined);
 
     try {
-      devPrint(pageUrl);
       const paginatedResponse = await getLeaderboardDataHandlerFromType(type)(
         order,
         pageUrl
       );
-      devPrint(paginatedResponse);
       if (paginatedResponse.data) {
         setLeaderboardData(paginatedResponse.data);
         leaderboardCache.set(cacheKey, {

--- a/src/hooks/useLeaderboard.tsx
+++ b/src/hooks/useLeaderboard.tsx
@@ -40,10 +40,15 @@ export const useLeaderboard = (type: LeaderboardType, order: Ordering) => {
     setError(undefined);
 
     try {
-      const data = await getLeaderboardDataHandlerFromType(type)(order);
-      if (data) {
-        setLeaderboardData(data);
-        leaderboardCache.set(cacheKey, { data, timestamp: now });
+      const paginatedResponse = await getLeaderboardDataHandlerFromType(type)(
+        order
+      );
+      if (paginatedResponse.data) {
+        setLeaderboardData(paginatedResponse.data);
+        leaderboardCache.set(cacheKey, {
+          data: paginatedResponse.data,
+          timestamp: now,
+        });
       }
     } catch (e) {
       const errorMessage = (e as Error).message;

--- a/src/services/leaderboard.ts
+++ b/src/services/leaderboard.ts
@@ -158,10 +158,11 @@ export function getNewGradLeaderboard(
 }
 
 export function getAttendanceLeaderboard(
-  orderBy: EngagementOrderBy = EngagementOrderBy.Attendance
+  orderBy: EngagementOrderBy = EngagementOrderBy.Attendance,
+  pageUrl?: string
 ): Promise<void | PaginatedLeaderboardResponse> {
   return api
-    .get(`/leaderboard/attendance/?order_by=${orderBy}`)
+    .get(pageUrl ?? `/leaderboard/attendance/?order_by=${orderBy}`)
     .then((res) => {
       if (res.status !== 200) {
         throw new Error('Failed to get attendance leaderboard');

--- a/src/services/leaderboard.ts
+++ b/src/services/leaderboard.ts
@@ -15,6 +15,9 @@ import {
   RawAttendanceStats,
   AttendanceStats,
   EngagementOrderBy,
+  RawPaginatedAttendanceResponse,
+  PaginatedAttendanceResponse,
+  PaginatedLeaderboardResponse,
 } from '../types';
 import { devPrint } from '../components/utils/RandomUtils';
 
@@ -72,35 +75,53 @@ function deserializeAttendanceStats({
   };
 }
 
+function deserializePaginatedAttendaceResponse({
+  results,
+  ...rest
+}: RawPaginatedAttendanceResponse): PaginatedAttendanceResponse {
+  return {
+    data: results.map(deserializeAttendanceStats),
+    ...rest,
+  };
+}
+
 export function getLeetcodeLeaderboard(
   orderBy: LeetCodeOrderBy = LeetCodeOrderBy.Total
-): Promise<LeetCodeStats[]> {
+): Promise<void | PaginatedLeaderboardResponse> {
   return api
     .get(`/leaderboard/leetcode/?order_by=${orderBy}`)
     .then((res) => {
       if (res.status !== 200)
         throw new Error('Failed to get leetcode leaderboard');
-      return res.data.map(deserializeLeetCodeStats);
+      return {
+        next: null,
+        previous: null,
+        data: res.data.map(deserializeLeetCodeStats),
+      };
     })
     .catch(devPrint);
 }
 
 export function getGitHubLeaderboard(
   orderBy: GitHubOrderBy = GitHubOrderBy.Commits
-): Promise<GitHubStats[]> {
+): Promise<void | PaginatedLeaderboardResponse> {
   return api
     .get(`/leaderboard/github/?order_by=${orderBy}`)
     .then((res) => {
       if (res.status !== 200)
         throw new Error('Failed to get github leaderboard');
-      return res.data.map(deserializeGitHubStats);
+      return {
+        next: null,
+        previous: null,
+        data: res.data.map(deserializeGitHubStats),
+      };
     })
     .catch(devPrint);
 }
 
 export function getInternshipLeaderboard(
   orderBy: ApplicationOrderBy = ApplicationOrderBy.Applied
-): Promise<ApplicationStats[]> {
+): Promise<void | PaginatedLeaderboardResponse> {
   return api
     .get(`/leaderboard/internship/?order_by=${orderBy}`)
     .then((res) => {
@@ -108,14 +129,18 @@ export function getInternshipLeaderboard(
         throw new Error('Failed to get internship application leaderboard');
       }
 
-      return res.data.map(deserializeApplicationStats);
+      return {
+        next: null,
+        previous: null,
+        data: res.data.map(deserializeApplicationStats),
+      };
     })
     .catch(devPrint);
 }
 
 export function getNewGradLeaderboard(
   orderBy: ApplicationOrderBy = ApplicationOrderBy.Applied
-): Promise<ApplicationStats[]> {
+): Promise<void | PaginatedLeaderboardResponse> {
   return api
     .get(`/leaderboard/newgrad/?order_by=${orderBy}`)
     .then((res) => {
@@ -123,14 +148,18 @@ export function getNewGradLeaderboard(
         throw new Error('Failed to get new grad application leaderboard');
       }
 
-      return res.data.map(deserializeApplicationStats);
+      return {
+        data: res.data.map(deserializeApplicationStats),
+        next: null,
+        previous: null,
+      };
     })
     .catch(devPrint);
 }
 
 export function getAttendanceLeaderboard(
   orderBy: EngagementOrderBy = EngagementOrderBy.Attendance
-): Promise<ApplicationStats[]> {
+): Promise<void | PaginatedLeaderboardResponse> {
   return api
     .get(`/leaderboard/attendance/?order_by=${orderBy}`)
     .then((res) => {
@@ -138,7 +167,11 @@ export function getAttendanceLeaderboard(
         throw new Error('Failed to get attendance leaderboard');
       }
 
-      return res.data.map(deserializeAttendanceStats);
+      const deserializedResponse = deserializePaginatedAttendaceResponse(
+        res.data
+      );
+
+      return deserializedResponse;
     })
     .catch(devPrint);
 }

--- a/src/services/leaderboard.ts
+++ b/src/services/leaderboard.ts
@@ -75,7 +75,7 @@ function deserializeAttendanceStats({
   };
 }
 
-function deserializePaginatedAttendaceResponse({
+function deserializePaginatedAttendanceResponse({
   results,
   ...rest
 }: RawPaginatedAttendanceResponse): PaginatedAttendanceResponse {
@@ -168,7 +168,7 @@ export function getAttendanceLeaderboard(
         throw new Error('Failed to get attendance leaderboard');
       }
 
-      const deserializedResponse = deserializePaginatedAttendaceResponse(
+      const deserializedResponse = deserializePaginatedAttendanceResponse(
         res.data
       );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -186,7 +186,8 @@ export type Ordering =
   | ApplicationOrderBy
   | EngagementOrderBy;
 export type LeaderboardDataHandler = (
-  order: Ordering
+  order: Ordering,
+  pageUrl?: string
 ) => Promise<PaginatedLeaderboardResponse>;
 
 export enum SortDirection {

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,10 +123,9 @@ export interface AttendanceStats extends LeaderboardEntry {
 }
 
 export interface PaginatedAttendanceResponse {
-  count: number;
   next: string | null;
   previous: string | null;
-  results: AttendanceStats[];
+  data: AttendanceStats[];
 }
 
 export enum LeaderboardType {
@@ -188,9 +187,15 @@ export type Ordering =
   | EngagementOrderBy;
 export type LeaderboardDataHandler = (
   order: Ordering
-) => Promise<LeaderboardEntry[]>;
+) => Promise<PaginatedLeaderboardResponse>;
 
 export enum SortDirection {
   Asc = 'asc',
   Desc = 'desc',
 }
+
+export type PaginatedLeaderboardResponse = {
+  next: string | null;
+  previous: string | null;
+  data: LeaderboardEntry[];
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,13 @@ export interface ApplicationStats extends LeaderboardEntry {
   applied: number;
 }
 
+export interface RawPaginatedAttendanceResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: RawAttendanceStats[];
+}
+
 export interface RawAttendanceStats {
   id: number;
   member: {
@@ -113,6 +120,13 @@ export interface RawAttendanceStats {
 
 export interface AttendanceStats extends LeaderboardEntry {
   sessionsAttended: number;
+}
+
+export interface PaginatedAttendanceResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: AttendanceStats[];
 }
 
 export enum LeaderboardType {


### PR DESCRIPTION
Author: Advay

## What changes were made?
- Update leaderboard types to support pagination by default, but make it null by default to avoid breaking changes
- Update the `useLeaderboard` hook to implement pagination when required
- Update leaderboard cache to handle pagination 
- Add pagination UI and functionality to the attendance session leaderboard

## (If applicable) Screenshots of your changes. Providing an “old vs. new” comparison would be great!
![image](https://github.com/user-attachments/assets/9af3da1e-ada3-441a-a42c-f02063eb6b56)
![image](https://github.com/user-attachments/assets/8c046098-0f8d-45d7-a105-2e7a7fa14da1)
