### PR TITLE
Use page numbers instead of page urls in attendance leaderboard

### DIFF
--- a/src/components/AttendanceLeaderboard.tsx
+++ b/src/components/AttendanceLeaderboard.tsx
@@ -125,7 +125,7 @@ export const AttendanceLeaderboard: React.FC<Props> = ({
         />
         <HStack w="100%" justify="center" mt={2}>
           <Button
-            isDisabled={!(page > 1)}
+            isDisabled={page == 1}
             onClick={() => {
               setPage(page - 1);
             }}
@@ -133,7 +133,7 @@ export const AttendanceLeaderboard: React.FC<Props> = ({
             Previous
           </Button>
           <Button
-            isDisabled={!(page < totalPages)}
+            isDisabled={page == totalPages}
             onClick={() => {
               setPage(page + 1);
             }}

--- a/src/components/AttendanceLeaderboard.tsx
+++ b/src/components/AttendanceLeaderboard.tsx
@@ -11,6 +11,7 @@ import Leaderboard from './Leaderboard';
 import { OrderBySelect } from './OrderBySelect';
 import { lastUpdated } from '../utils';
 import { useLeaderboard } from '../hooks/useLeaderboard';
+import { ATTENDANCE_PAGE_SIZE } from '../services/leaderboard';
 
 interface Props {
   order: EngagementOrderBy;
@@ -29,15 +30,16 @@ export const AttendanceLeaderboard: React.FC<Props> = ({
     SortDirection.Desc
   );
 
-  const [pageUrl, setPageUrl] = useState<string>();
+  const [page, setPage] = useState(1);
 
   const {
     isLoading,
     error,
     leaderboardData: attendanceData,
-    nextPage,
-    previousPage,
-  } = useLeaderboard(LeaderboardType.Attendance, order, pageUrl);
+    count,
+  } = useLeaderboard(LeaderboardType.Attendance, order, page);
+
+  const totalPages = Math.ceil(count! / ATTENDANCE_PAGE_SIZE);
 
   if (isLoading) {
     return (
@@ -123,17 +125,17 @@ export const AttendanceLeaderboard: React.FC<Props> = ({
         />
         <HStack w="100%" justify="center" mt={2}>
           <Button
-            isDisabled={!previousPage}
+            isDisabled={!(page > 1)}
             onClick={() => {
-              setPageUrl(previousPage!);
+              setPage(page - 1);
             }}
           >
             Previous
           </Button>
           <Button
-            isDisabled={!nextPage}
+            isDisabled={!(page < totalPages)}
             onClick={() => {
-              setPageUrl(nextPage!);
+              setPage(page + 1);
             }}
           >
             Next

--- a/src/services/leaderboard.ts
+++ b/src/services/leaderboard.ts
@@ -159,12 +159,17 @@ export function getNewGradLeaderboard(
     .catch(devPrint);
 }
 
+export const ATTENDANCE_PAGE_SIZE = 50;
+
 export function getAttendanceLeaderboard(
   orderBy: EngagementOrderBy = EngagementOrderBy.Attendance,
-  pageUrl?: string
+  page: number = 1,
+  pageSize: number = ATTENDANCE_PAGE_SIZE
 ): Promise<void | PaginatedLeaderboardResponse> {
   return api
-    .get(pageUrl ?? `/leaderboard/attendance/?order_by=${orderBy}`)
+    .get(
+      `/leaderboard/attendance/?order_by=${orderBy}&page=${page}&page_size=${pageSize}`
+    )
     .then((res) => {
       if (res.status !== 200) {
         throw new Error('Failed to get attendance leaderboard');

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,6 +128,7 @@ export interface PaginatedAttendanceResponse {
   next: string | null;
   previous: string | null;
   data: AttendanceStats[];
+  count: number;
 }
 
 export enum LeaderboardType {
@@ -189,7 +190,8 @@ export type Ordering =
   | EngagementOrderBy;
 export type LeaderboardDataHandler = (
   order: Ordering,
-  pageUrl?: string
+  page?: number,
+  pageSize?: number
 ) => Promise<PaginatedLeaderboardResponse>;
 
 export enum SortDirection {
@@ -201,4 +203,5 @@ export type PaginatedLeaderboardResponse = {
   next: string | null;
   previous: string | null;
   data: LeaderboardEntry[];
+  count?: number;
 };


### PR DESCRIPTION
Author: Advay

## What changes were made?
- In production, using page urls was causing a bug related to a mismatch in security (http vs https)
- Instead of page urls like the original implementation, I refactored to just use page numbers instead, similar to what is done in the directory page
